### PR TITLE
Add local env to exec

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ loop:
 	}
 
 	cmd := exec.Command(helmPath, os.Args[1:]...)
+	cmd.Env = os.Environ()
 
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Pass `env` to exec command for `HELM_PLUGINS` var when Helm is a temporary directory (use case in ArgoCD).