### PR TITLE
bugfix: fix hidden YAML decoding issues by returning a proper exit code

### DIFF
--- a/helm_wrapper.go
+++ b/helm_wrapper.go
@@ -185,13 +185,13 @@ func (c *HelmWrapper) RunHelm() {
 		}
 
 		var encrypted bool
-		file, err := ReadAndUnmarshalYaml(filename)
+		fileData, err := ReadAndUnmarshalYaml(filename)
 		if err != nil {
 			c.ExitCode = 1
-			_ = c.errorf("failed to read file '%s': %s", filename, err)
+			_ = c.errorf("failed to read or unmarshal file '%s': %s", filename, err)
 			return
 		}
-		encrypted = DetectSopsKey(file)
+		encrypted = DetectSopsKey(fileData)
 		if err != nil {
 			return
 		}

--- a/helm_wrapper.go
+++ b/helm_wrapper.go
@@ -185,11 +185,17 @@ func (c *HelmWrapper) RunHelm() {
 		}
 
 		var encrypted bool
-		encrypted, err = DetectSopsYaml(filename)
+		file, err := ReadAndUnmarshalYaml(filename)
 		if err != nil {
-			_ = c.errorf("error checking if file is encrypted: %s", err)
+			c.ExitCode = 1
+			_ = c.errorf("failed to read file '%s': %s", filename, err)
 			return
 		}
+		encrypted = DetectSopsKey(file)
+		if err != nil {
+			return
+		}
+
 		if !encrypted {
 			continue
 		}
@@ -230,7 +236,7 @@ func (c *HelmWrapper) RunHelm() {
 	}
 }
 
-// Cleaning function defered from RunHelm function and used to do pipe cleanup
+// Cleaning function deferred from RunHelm function and used to do pipe cleanup
 func (c *HelmWrapper) cleanPipes() {
 	close(c.cleanPipeFns)
 	for cleanFn := range c.cleanPipeFns {

--- a/utils.go
+++ b/utils.go
@@ -6,20 +6,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func DetectSopsYaml(filename string) (bool, error) {
+func ReadAndUnmarshalYaml(filename string) (map[string]interface{}, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	var sf map[string]interface{}
 	err = yaml.Unmarshal(data, &sf)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	if _, ok := sf["sops"]; ok {
-		return true, nil
-	}
-	return false, nil
+	return sf, nil
+}
+
+func DetectSopsKey(sf map[string]interface{}) bool {
+	_, ok := sf["sops"]
+	return ok
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-    "testing"
-    "io/ioutil"
-    "os"
+	"io/ioutil"
+	"os"
+	"testing"
 )
 
 func TestDetectSopsFile(t *testing.T) {
@@ -18,7 +18,8 @@ func TestDetectSopsFile(t *testing.T) {
 	tmp.WriteString(`---
 secret: hello
 `)
-	res, err := DetectSopsYaml(tmp.Name())
+	fileData, err := ReadAndUnmarshalYaml(tmp.Name())
+	res := DetectSopsKey(fileData)
 	if res != false || err != nil {
 		t.Errorf("DetectSopsYaml(tmp) = %t, %v; want false, <nil>", res, err)
 	}
@@ -36,7 +37,8 @@ sops:
     pgp: []
     version: 3.6.1
 `)
-	res, err = DetectSopsYaml(tmp.Name())
+	fileData, err = ReadAndUnmarshalYaml(tmp.Name())
+	res = DetectSopsKey(fileData)
 	if res != true || err != nil {
 		t.Errorf("DetectSopsYaml(tmp) = %t, %v; want true, <nil>", res, err)
 	}


### PR DESCRIPTION
This pull request solves the problem of ArgoCD applications not being correctly rendered. The scenario look as follow:

If any YAML file going through the "DetectSopsYaml" function  has incorrectly a duplicated key (see below) like this:

```
data:
  value1: foo
  value2: bar
  value1: foobar
```

then the decoding of this file will cause following error log with the system exit code 0

`unmarshal errors: line 4: mapping key "value1" already defined at line 2`

the file is being then skipped causing that the Chart is not being correctly rendered and ArgoCD does not get any information about the YAML error but instead it gets a bad rendered Chart.






