### PR TITLE
fix(exit-code): catch exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ To enable it, run `git config --global diff.sops.textconv sops-git-diff-helper` 
 ```
 *.yaml diff=sops
 ```
+
+## Contribute and test
+In order to run test, the dev sops pgp key should be imported first, as explained [here](https://github.com/getsops/sops?tab=readme-ov-file#21test-with-the-dev-pgp-key).

--- a/main.go
+++ b/main.go
@@ -37,5 +37,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "[helm-sops] Error: %s\n", err)
 	}
 
+	if len(w.Errors) > 0 && w.ExitCode == 0 {
+		w.ExitCode = 10
+	}
+
 	os.Exit(w.ExitCode)
 }


### PR DESCRIPTION
In some case, the program exit with error and exit code of zero. Change this to exit with non zero code each time the list of error is not empty.